### PR TITLE
config mode to captive portal

### DIFF
--- a/hydrometer.ino
+++ b/hydrometer.ino
@@ -90,7 +90,7 @@ void setup() {
       lights.toggleRed();
     }
     if (!initWiFi(ssid, pass)) {
-      if (FileSystem::getConsecutiveFailures() > FileSystem::getAllowedFailures()) {
+      if (configMode || (FileSystem::getConsecutiveFailures() > FileSystem::getAllowedFailures())) {
         // purging the files to drop down to captive portal mode
         FileSystem::clearAll();
         ESP.restart();


### PR DESCRIPTION
if we can't connect to wifi ONCE while restarting in config mode, drop to captive portal. This makes it easier to reset.